### PR TITLE
docs: refresh integration links

### DIFF
--- a/Demo/PangleQuickStartDemo/Quick-Start-Manual/en/1-integrate_en.md
+++ b/Demo/PangleQuickStartDemo/Quick-Start-Manual/en/1-integrate_en.md
@@ -10,7 +10,7 @@ This chapter will explain the procedure for integrating and Initializing the Pan
 
 <a name="start/ios14"></a>
 ## About iOS 14
-Please follow [iOS 14 actions](https://www.pangleglobal.com/help/doc/5f4dc4271de305000ece82aa) to enable SKAdNetwork and include App Tracking Transparency.
+Please follow [iOS 14 actions](https://www.pangleglobal.com/integration/ios14-readiness) to enable SKAdNetwork and include App Tracking Transparency.
 
 - Please make sure to add Pangle's SKAdNetwork IDs to your app's info.plist.
 ```xml

--- a/Demo/PangleQuickStartDemo/Quick-Start-Manual/en/6-mediation_en.md
+++ b/Demo/PangleQuickStartDemo/Quick-Start-Manual/en/6-mediation_en.md
@@ -2,21 +2,15 @@
 
 This chapter will introduce mediation adnetworks which support Panlge.
 
-* [Mopub](#mopub)
-* [ironSource](#ironsource)
+* [Unity LevelPlay](#ironsource)
 * [MAX](#max)
 * [Admob](#admob)
 
 
-<a name="mopub"></a>
-## Mopub
-
-Mopub official support Pangle via the mediation. You can find details from [Mediation Panlge](https://developers.mopub.com/publishers/mediation/networks/pangle/).
-
 <a name="ironsource"></a>
-## ironSource
+## Unity LevelPlay
 
-ironSource official support Pangle via the mediation. You can find details from [Pangle Integration Guide](https://developers.ironsrc.com/ironsource-mobile/ios/pangle-integration-guide/#step-1).
+Unity LevelPlay supports Pangle via mediation. See the current [Pangle integration guide](https://docs.unity.com/en-us/grow/levelplay/sdk/ios/networks/guides/pangle).
 
 <a name="max"></a>
 ## MAX

--- a/Demo/PangleQuickStartDemo/Quick-Start-Manual/ja/1-integrate_ja.md
+++ b/Demo/PangleQuickStartDemo/Quick-Start-Manual/ja/1-integrate_ja.md
@@ -10,7 +10,7 @@
 
 <a name="start/ios14"></a>
 ## iOS 14の対応
-[iOS 14 actions](https://www.pangleglobal.com/help/doc/5f4dc4271de305000ece82aa)に従って、`SKAdNetwork`と`App Tracking Transparency`の対応をしてください。
+[iOS 14 actions](https://www.pangleglobal.com/integration/ios14-readiness)に従って、`SKAdNetwork`と`App Tracking Transparency`の対応をしてください。
 
 - PangleのSKAdNetwork IDをアプリのinfo.plistに必ず追加してください。
 ```xml

--- a/Demo/PangleQuickStartDemo/Quick-Start-Manual/ja/6-mediation_ja.md
+++ b/Demo/PangleQuickStartDemo/Quick-Start-Manual/ja/6-mediation_ja.md
@@ -2,21 +2,15 @@
 
 本章ではPangle iOS SDKとメディエーションできる他のアドネットワークとについて記述します。
 
-* [Mopub](#mopub)
-* [ironSource](#ironsource)
+* [Unity LevelPlay](#ironsource)
 * [MAX](#max)
 * [Admob](#admob)
 
 
-<a name="mopub"></a>
-## Mopub
-
-Mopubメディエーションはオフィシャルサポートされています。詳細はMopubでの[Mediation Panlge](https://developers.mopub.com/publishers/mediation/networks/pangle/)をご参考ください。
-
 <a name="ironsource"></a>
-## ironSource
+## Unity LevelPlay
 
-ironSourceメディエーションはオフィシャルサポートされています。詳細は[Pangle Integration Guide](https://developers.ironsrc.com/ironsource-mobile/ios/pangle-integration-guide/#step-1)をご参考ください。
+Unity LevelPlayではPangleメディエーションがサポートされています。詳細は現在の[Pangle Integration Guide](https://docs.unity.com/en-us/grow/levelplay/sdk/ios/networks/guides/pangle)をご参考ください。
 
 <a name="max"></a>
 ## MAX

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Pod for Bytedance-UnionAD only support **x86_64, armv7, arm64, i386**.
 ## How To Get Started
 
 + [Download Bytedance-UnionAD](https://github.com/bytedance/Bytedance-UnionAD/tree/master) and try out the included [example app](https://github.com/bytedance/Bytedance-UnionAD/tree/master/Demo)
-+ Check out the [documentation](https://www.pangle.cn/help/doc/5fc4f25f7b550100157c01d0) for a comprehensive look at all of the APIs available in Bytedance-UnionAD
-+ If you have other questions, please read [FAQ](https://www.pangle.cn/help/doc/5dd0fe618507820012088272) first
++ Check out the [documentation](https://www.csjplatform.com/supportcenter/28721) for a comprehensive look at all of the APIs available in Bytedance-UnionAD
++ If you have other questions, please read [FAQ](https://www.csjplatform.com/supportcenter/5415) first
 + We provide a [**Quick Start**](https://github.com/bytedance/Bytedance-UnionAD/tree/master/Demo/PangleQuickStartDemo) to help you to easily integrate and use the SDK.
 
 ## Installation with CocoaPods
@@ -54,8 +54,8 @@ Bytedance-UnionAD is available under the MIT license. See the LICENSE file for m
 
 ## FAQ & feedback channel
 Chinese developers could refer to the documentation on the Pangle whenever encountered any problems during the integration process:
-- FAQ document:  https://www.pangle.cn/help/doc/5dd0fe618507820012088272
-- Error code reference document:https://www.pangle.cn/help/doc/5de4cc6d78c8690012a90aa5
+- FAQ document:  https://www.csjplatform.com/supportcenter/5415
+- Error code reference document:https://www.csjplatform.com/supportcenter/5421
 
 
 Global developers can refer to the help center: https://www.pangleglobal.com/help
@@ -66,4 +66,4 @@ If the content of the document cannot solve your problem, you can try to give fe
 - Pangle will invite some developers to grayscale the new version of the SDK, please pay attention to the notice in the station. You can send an email to union_tech_support@bytedance.com to apply for the new version of the Pangle SDK. Your participation is highly appreciated!
 
 
-[Change Log](https://www.pangle.cn/help/doc/5fbdb6811ee5c2001d3f0ca5)
+[Change Log](https://www.csjplatform.com/supportcenter/5373)


### PR DESCRIPTION
## Summary

- replace four unavailable Pangle China documentation URLs with their maintained support-center pages
- point both English and Japanese iOS 14 guidance to the current readiness guide
- remove the retired MoPub section in both languages and update ironSource branding/link to the current Unity LevelPlay guide

## Root cause

The documentation had not been refreshed since 2021. Several legacy URLs either render an unavailable-document page despite returning HTTP 200, no longer resolve, or redirect to a generic landing page.

## Verification

- verified all six replacement targets return HTTP 200 and the Pangle China targets do not render `该文档无法访问`
- scanned all tracked Markdown files and confirmed none of the retired URLs remain
- checked every relative Markdown link and image target across the repository; all resolve locally
- ran `git diff --check`

Fixes #227