### PR TITLE
fix: correct SKAdNetwork item

### DIFF
--- a/Demo/PangleQuickStartDemo/PangleQuickStartDemo/Info.plist
+++ b/Demo/PangleQuickStartDemo/PangleQuickStartDemo/Info.plist
@@ -67,7 +67,7 @@
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>
-			<key>22mmun2rn5.skadnetwork</key>
+			<key>SKAdNetworkIdentifier</key>
 			<string>22mmun2rn5.skadnetwork</string>
 		</dict>
 		<dict>

--- a/Demo/PangleQuickStartDemo/PangleQuickStartDemoTests/PangleQuickStartDemoTests.swift
+++ b/Demo/PangleQuickStartDemo/PangleQuickStartDemoTests/PangleQuickStartDemoTests.swift
@@ -5,6 +5,7 @@
 //  Created by Chan Gu on 2020/10/07.
 //
 
+import Foundation
 import XCTest
 @testable import PangleQuickStartDemo
 
@@ -21,6 +22,23 @@ class PangleQuickStartDemoTests: XCTestCase {
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testSKAdNetworkItemsHaveIdentifiers() throws {
+        let testBundleURL = Bundle(for: PangleQuickStartDemoTests.self).bundleURL
+        let appBundleURL = testBundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let appBundle = try XCTUnwrap(Bundle(url: appBundleURL))
+        let items = try XCTUnwrap(
+            appBundle.object(forInfoDictionaryKey: "SKAdNetworkItems") as? [[String: Any]]
+        )
+
+        XCTAssertFalse(items.isEmpty)
+        for item in items {
+            let identifier = try XCTUnwrap(item["SKAdNetworkIdentifier"] as? String)
+            XCTAssertFalse(identifier.isEmpty)
+        }
     }
 
     func testPerformanceExample() throws {


### PR DESCRIPTION
## Summary

- correct the first Quick Start `SKAdNetworkItems` dictionary to use Apple's `SKAdNetworkIdentifier` key
- add a hosted unit test that checks every built app entry has a non-empty identifier

## Root cause

The first identifier value was used as the dictionary key, so iOS could not recognize that entry as an SKAdNetwork identifier.

## Verification

- parsed all 11 tracked property lists with Python `plistlib`
- verified both Quick Start SKAdNetwork entries use non-empty `SKAdNetworkIdentifier` values
- `git diff --check`

The added XCTest was not run because this audit host is Windows and does not provide Xcode or `xcodebuild`.

Fixes #229